### PR TITLE
Fixing the contact form for devices with width less than 880px

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "react-portfolio",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.14.1",

--- a/src/css/Contact.css
+++ b/src/css/Contact.css
@@ -154,10 +154,10 @@
   }
 
   .contact-right-wrapper input {
-    width: 100%;
+    width: 90%;
   }
 
   .contact-right-wrapper textarea {
-    width: 100%;
+    width: 90%;
   }
 }


### PR DESCRIPTION
Solved #55 by restricting the form to 90% of the width of the screen.

Initial:
![image](https://user-images.githubusercontent.com/51889135/136644491-5c042b9f-a992-4b8a-8eef-c09c7c4691f8.png)

Final:
![image](https://user-images.githubusercontent.com/51889135/136644507-6aab4833-8d5b-4595-a95e-0c46690366b9.png)
